### PR TITLE
Fix copying of files

### DIFF
--- a/lib/container.ts
+++ b/lib/container.ts
@@ -3,7 +3,7 @@ import * as Dockerode from 'dockerode';
 import { EventEmitter } from 'events';
 import * as _ from 'lodash';
 import { fs } from 'mz';
-import * as path from 'path';
+import * as Path from 'path';
 import * as escape from 'shell-escape';
 import * as shell from 'shell-quote';
 import * as Stream from 'stream';
@@ -74,6 +74,9 @@ interface ContainerEvents {
 type ContainerEventEmitter = StrictEventEmitter<EventEmitter, ContainerEvents>;
 
 export class Container extends (EventEmitter as {
+	// We need to avoid the tslint errors here, as typescript
+	// will not accept the changes proposed
+	// tslint:disable-next-line
 	new (): ContainerEventEmitter;
 }) {
 	private dockerfile: Dockerfile;
@@ -154,7 +157,7 @@ export class Container extends (EventEmitter as {
 				const pack = tar.pack();
 
 				for (const operation of operations) {
-					const pathOnDisk = path.join(
+					const pathOnDisk = Path.join(
 						this.hostContextPath,
 						operation.fromPath,
 					);
@@ -162,7 +165,7 @@ export class Container extends (EventEmitter as {
 					await this.addFileToTarPack(
 						pack,
 						pathOnDisk,
-						path.relative(destination, operation.toPath),
+						Path.relative(destination, operation.toPath),
 					);
 				}
 
@@ -201,7 +204,7 @@ export class Container extends (EventEmitter as {
 		// TODO: This could be made more efficient, as we could integrate
 		// the subdirectories into a single group, as this can be done
 		// when uploading with a tar file
-		return _.groupBy(ops, op => path.dirname(op.toPath));
+		return _.groupBy(ops, op => Path.dirname(op.toPath));
 	}
 
 	private getAddOperations(
@@ -242,10 +245,10 @@ export class Container extends (EventEmitter as {
 			// is a directory
 			const strippedPath = matchingDep.sourceIsDirectory
 				? f
-				: f.split(path.sep).pop()!;
+				: f.split(Path.sep).pop()!;
 
 			const toPath = matchingDep.destinationIsDirectory
-				? path.join(matchingDep.containerPath, strippedPath)
+				? Path.join(matchingDep.containerPath, strippedPath)
 				: matchingDep.containerPath;
 
 			return {
@@ -297,7 +300,20 @@ export class Container extends (EventEmitter as {
 	}
 
 	private static generateContainerCommand(command: string): string[] {
-		return shell.parse(escape(['/bin/sh', '-c', `${command}`]));
+		return shell.parse(escape(['/bin/sh', '-c', `${command}`])).map(entry => {
+			if (!_.isString(entry)) {
+				const entryObj: { [key: string]: string } = entry;
+				if (entryObj.op != null) {
+					if (entryObj.op === 'glob') {
+						return entryObj.pattern;
+					} else {
+						return entryObj.op;
+					}
+				}
+				return '';
+			}
+			return entry;
+		});
 	}
 }
 

--- a/lib/container.ts
+++ b/lib/container.ts
@@ -240,8 +240,12 @@ export class Container extends (EventEmitter as {
 			// TODO: I'm not sure the logic here is actually correct,
 			// specifically the way we build the destination when the containerPath
 			// is a directory
+			const strippedPath = matchingDep.sourceIsDirectory
+				? f
+				: f.split(path.sep).pop()!;
+
 			const toPath = matchingDep.destinationIsDirectory
-				? path.join(matchingDep.containerPath, f.split(path.sep).pop()!)
+				? path.join(matchingDep.containerPath, strippedPath)
 				: matchingDep.containerPath;
 
 			return {

--- a/lib/container.ts
+++ b/lib/container.ts
@@ -191,22 +191,8 @@ export class Container extends (EventEmitter as {
 		destination: string,
 	): Promise<void> {
 		const stat = await fs.stat(path);
-		await new Promise((resolve, reject) => {
-			const entry = pack.entry(
-				{ name: destination, size: stat.size },
-				(err?: Error) => {
-					if (err) {
-						reject(err);
-					} else {
-						resolve();
-					}
-				},
-			);
 
-			const readStream = fs.createReadStream(path);
-			readStream.on('error', reject);
-			readStream.pipe(entry);
-		});
+		pack.entry({ name: destination, size: stat.size }, await fs.readFile(path));
 	}
 
 	private getAddOperationsByDestination(

--- a/lib/dockerfile.ts
+++ b/lib/dockerfile.ts
@@ -34,6 +34,10 @@ export interface FileDependency {
 	 * Does the container path point to a directory or a file?
 	 */
 	destinationIsDirectory: boolean;
+	/**
+	 * Does the source path point to a directory or file?
+	 */
+	sourceIsDirectory: boolean;
 }
 
 export type Command = string;
@@ -248,10 +252,12 @@ class Dockerfile {
 		}
 
 		return copyArgs.map(arg => {
+			const normalized = path.normalize(arg);
 			return {
-				localPath: path.normalize(arg),
+				localPath: normalized,
 				containerPath: dest,
 				destinationIsDirectory: isDir || Dockerfile.isDirectory(dest),
+				sourceIsDirectory: Dockerfile.isDirectory(normalized),
 			};
 		});
 	}

--- a/test/container.spec.ts
+++ b/test/container.spec.ts
@@ -378,6 +378,37 @@ describe('Containers', () => {
 						.that.equals(fileB);
 				});
 
+				it('should correctly consider subdirectories when copying files', async () => {
+					const context = path.join(__dirname, 'contexts', 'b');
+
+					const container = new Container(
+						await readFile(path.join(context, 'Dockerfile'), {
+							encoding: 'utf8',
+						}),
+						context,
+						currentContainer.id,
+						docker,
+					);
+
+					const changedFiles = new FileUpdates({
+						updated: ['test/test.ts'],
+						deleted: [],
+						added: [],
+					});
+
+					const actions = container.actionsNeeded(changedFiles);
+					expect(actions).to.have.length(1);
+
+					expect(
+						(container as any).getOperations(['test/test.ts'], actions[0]),
+					).to.deep.equal([
+						{
+							fromPath: 'test/test.ts',
+							toPath: '/usr/src/app/test/test.ts',
+						},
+					]);
+				});
+
 				it('should throw an error when the container is not running', done => {
 					const dockerfileContent = [
 						`FROM ${image}`,

--- a/test/contexts/b/Dockerfile
+++ b/test/contexts/b/Dockerfile
@@ -1,0 +1,5 @@
+FROM image
+
+COPY . /usr/src/app/
+
+CMD cmd

--- a/test/contexts/b/test/test.ts
+++ b/test/contexts/b/test/test.ts
@@ -1,0 +1,1 @@
+console.log('test');

--- a/test/dockerfile.spec.ts
+++ b/test/dockerfile.spec.ts
@@ -71,6 +71,7 @@ describe('Dockerfile inspection', () => {
 			expect(actionGroup.fileDependencies[0]).to.deep.equal({
 				localPath: 'a.ts',
 				destinationIsDirectory: false,
+				sourceIsDirectory: false,
 				containerPath: '/b.ts',
 			});
 			expect(actionGroup.commands).to.deep.equal([
@@ -103,6 +104,7 @@ describe('Dockerfile inspection', () => {
 			expect(actionGroup.fileDependencies[0]).to.deep.equal({
 				localPath: 'a.ts',
 				destinationIsDirectory: false,
+				sourceIsDirectory: false,
 				containerPath: '/b.ts',
 			});
 			expect(actionGroup.commands).to.deep.equal([
@@ -133,6 +135,7 @@ describe('Dockerfile inspection', () => {
 				{
 					localPath: 'a.ts',
 					destinationIsDirectory: false,
+					sourceIsDirectory: false,
 					containerPath: '/usr/src/app/b.ts',
 				},
 			]);
@@ -145,6 +148,7 @@ describe('Dockerfile inspection', () => {
 				{
 					localPath: 'c.ts',
 					destinationIsDirectory: false,
+					sourceIsDirectory: false,
 					containerPath: '/usr/src/app/src/d.ts',
 				},
 			]);
@@ -174,12 +178,14 @@ describe('Dockerfile inspection', () => {
 				{
 					localPath: 'c.ts',
 					destinationIsDirectory: true,
+					sourceIsDirectory: false,
 					containerPath: '/usr/src/app/',
 				},
 				{
 					localPath: 'd.ts',
 					destinationIsDirectory: true,
 					containerPath: '/usr/src/app/',
+					sourceIsDirectory: false,
 				},
 			]);
 		});
@@ -217,11 +223,13 @@ describe('Dockerfile inspection', () => {
 					{
 						localPath: 'a.test',
 						destinationIsDirectory: false,
+						sourceIsDirectory: false,
 						containerPath: '/usr/src/app/b.test',
 					},
 					{
 						localPath: 'c.test',
 						destinationIsDirectory: false,
+						sourceIsDirectory: false,
 						containerPath: '/usr/src/app/d.test',
 					},
 				],
@@ -245,6 +253,7 @@ describe('Dockerfile inspection', () => {
 				{
 					localPath: 'a.test',
 					destinationIsDirectory: true,
+					sourceIsDirectory: false,
 					containerPath: '/usr/src/app',
 				},
 			]);


### PR DESCRIPTION
We make sure to consider subdirectories when copying.

We also don't rely on the streaming interface of tar-stream, which is super unreliable.