### PR TITLE
Upgrades to Dockerfile parsing, for multistage support

### DIFF
--- a/lib/action-group.ts
+++ b/lib/action-group.ts
@@ -1,0 +1,67 @@
+/*
+Copyright 2019 Balena Ltd
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import * as _ from 'lodash';
+import * as minimatch from 'minimatch';
+import * as path from 'path';
+
+export type Command = string;
+
+export interface StageCopy {
+	source: string;
+	dest: string;
+	sourceStage: number;
+}
+
+export interface LocalCopy {
+	source: string;
+	dest: string;
+}
+
+interface ActionGroupCore {
+	commands: Command[];
+	workdir: string;
+}
+
+export interface StageDependentActionGroup extends ActionGroupCore {
+	dependentOnStage: true;
+	copies: StageCopy[];
+	stageDependency: number;
+}
+
+export interface LocalDependentActionGroup extends ActionGroupCore {
+	dependentOnStage: false;
+	copies: LocalCopy[];
+}
+
+export type ActionGroup = StageDependentActionGroup | LocalDependentActionGroup;
+
+// Exported for tests
+export function isChildPath(parent: string, child: string): boolean {
+	// from: https://stackoverflow.com/a/45242825/4193583
+	const relative = path.relative(parent, child);
+	return !!relative && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+export function fileMatchesForActionGroup(
+	files: string[],
+	actionGroup: ActionGroup,
+): string[] {
+	return _(actionGroup.copies)
+		.flatMap(({ source }) =>
+			files.filter(f => minimatch(f, source) || isChildPath(source, f)),
+		)
+		.uniq()
+		.value();
+}
+
+export default ActionGroup;

--- a/lib/stage.ts
+++ b/lib/stage.ts
@@ -1,0 +1,248 @@
+/*
+Copyright 2019 Balena Ltd
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import * as _ from 'lodash';
+import * as path from 'path';
+
+import ActionGroup, {
+	Command,
+	fileMatchesForActionGroup,
+	LocalCopy,
+	LocalDependentActionGroup,
+	StageDependentActionGroup,
+} from './action-group';
+import { DockerfileParseError, InternalInconsistencyError } from './errors';
+
+export class Stage {
+	public dependentOnStages: number[] = [];
+	public isLast: boolean = false;
+	public actionGroups: ActionGroup[] = [
+		{
+			dependentOnStage: false,
+			commands: [],
+			copies: [],
+			workdir: '/',
+		},
+	];
+
+	/*
+		This var is used to detect whether we create a new action group,
+		as we can collect as many copies together into the same action group,
+		but to ensure we run the commands in the correct order, a new copy forces
+		a new group
+	*/
+	private lastStepWasCopy: boolean = false;
+	private lastWorkdir: string = '/';
+	private ungroupedCommands: Command[] = [];
+
+	public constructor(
+		public index: number,
+		public name: string = index.toString(),
+	) {}
+
+	public addLocalCopyStep(args: string[]) {
+		const lastActionGroup = _.last(this.actionGroups);
+
+		if (args.length < 2) {
+			throw new DockerfileParseError(
+				'Minimum two arguments to COPY instruction!',
+			);
+		}
+		const checkedArgs = args as [string, string, ...string[]];
+
+		if (this.canAddCopyToGroup(false)) {
+			if (lastActionGroup.dependentOnStage) {
+				throw new InternalInconsistencyError(
+					'Attempt to add stage copy to local copy action group!',
+				);
+			}
+			const localActionGroup = lastActionGroup as LocalDependentActionGroup;
+			localActionGroup.copies = localActionGroup.copies.concat(
+				this.copyArgsToCopies(checkedArgs, localActionGroup),
+			);
+		} else {
+			lastActionGroup.commands = lastActionGroup.commands.concat(
+				this.ungroupedCommands,
+			);
+			const actionGroup: LocalDependentActionGroup = {
+				dependentOnStage: false,
+				commands: [],
+				copies: [],
+				workdir: this.lastWorkdir,
+			};
+			actionGroup.copies = this.copyArgsToCopies(checkedArgs, actionGroup);
+			this.actionGroups.push(actionGroup);
+			this.ungroupedCommands = [];
+		}
+
+		this.lastStepWasCopy = true;
+	}
+
+	public addStageCopyStep(args: string[], stageIdx: number) {
+		const lastActionGroup = _.last(this.actionGroups);
+
+		if (args.length < 2) {
+			throw new DockerfileParseError(
+				'Minimum two arguments to COPY instruction!',
+			);
+		}
+
+		const checkedArgs = args as [string, string, ...string[]];
+
+		if (this.canAddCopyToGroup(true, stageIdx)) {
+			if (!lastActionGroup.dependentOnStage) {
+				throw new Error(
+					'Attempt to add local copy to stage copy action group!',
+				);
+			}
+
+			lastActionGroup.copies.concat(
+				this.copyArgsToCopies(checkedArgs, lastActionGroup).map(copy => ({
+					sourceStage: stageIdx,
+					...copy,
+				})),
+			);
+		} else {
+			lastActionGroup.commands = lastActionGroup.commands.concat(
+				this.ungroupedCommands,
+			);
+			const actionGroup: StageDependentActionGroup = {
+				dependentOnStage: true,
+				commands: [],
+				stageDependency: stageIdx,
+				copies: [],
+				workdir: this.lastWorkdir,
+			};
+
+			actionGroup.copies = this.copyArgsToCopies(checkedArgs, actionGroup).map(
+				copy => ({
+					sourceStage: stageIdx,
+					...copy,
+				}),
+			);
+
+			this.actionGroups.push(actionGroup);
+			this.ungroupedCommands = [];
+		}
+
+		this.lastStepWasCopy = true;
+
+		this.dependentOnStages = _.uniq(this.dependentOnStages.concat(stageIdx));
+	}
+
+	public addCommandStep(command: string) {
+		this.ungroupedCommands.push(command);
+		this.lastStepWasCopy = false;
+	}
+
+	public addWorkdirStep(workdir: string) {
+		// We need to create a new group, saving any ungrouped commands into
+		// the latest group
+		const actionGroup = _.last(this.actionGroups)!;
+		actionGroup.commands = actionGroup.commands.concat(this.ungroupedCommands);
+		this.actionGroups.push({
+			copies: [],
+			dependentOnStage: false,
+			commands: [],
+			workdir,
+		});
+		this.lastWorkdir = workdir;
+		this.ungroupedCommands = [];
+		this.lastStepWasCopy = false;
+	}
+
+	public finalize() {
+		const actionGroup = _.last(this.actionGroups) as ActionGroup;
+		actionGroup.commands = actionGroup.commands.concat(this.ungroupedCommands);
+
+		// Also filter any action groups which do not have commands or copies,
+		// as these are pointless
+		this.actionGroups = _.reject(
+			this.actionGroups,
+			ag => ag.commands.length === 0 && ag.copies.length === 0,
+		);
+	}
+
+	public getActionGroupsForChangedFiles(files: string[]): ActionGroup[] {
+		// Go through the action groups in order, checking if the file should
+		// trigger the group, and returning every action group that follows
+		for (const [idx, actionGroup] of this.actionGroups.entries()) {
+			if (actionGroup.dependentOnStage) {
+				// We're not interested in stage copies
+				continue;
+			}
+			const matches = fileMatchesForActionGroup(files, actionGroup);
+			if (matches.length > 0) {
+				// return this + everything after it
+				return this.actionGroups.slice(idx);
+			}
+		}
+		return [];
+	}
+
+	public getActionGroupsForChangedStage(stageIdx: number): ActionGroup[] {
+		for (const [idx, actionGroup] of this.actionGroups.entries()) {
+			if (!actionGroup.dependentOnStage) {
+				// We're not interested in non-stage copies
+				continue;
+			}
+			if (actionGroup.stageDependency === stageIdx) {
+				return this.actionGroups.slice(idx);
+			}
+		}
+
+		return [];
+	}
+
+	private canAddCopyToGroup(dependentOnStage: false): boolean;
+	private canAddCopyToGroup(dependentOnStage: true, stageIdx: number): boolean;
+	private canAddCopyToGroup(
+		dependentOnStage: boolean,
+		stageIdx?: number,
+	): boolean {
+		if (this.lastStepWasCopy) {
+			const actionGroup = _.last(this.actionGroups) as ActionGroup;
+			// the last step's last addition was a copy. We can add it to the
+			// same group iff the stage dependency matches (or lack thereof)
+			if (dependentOnStage) {
+				return (
+					actionGroup.dependentOnStage &&
+					actionGroup.stageDependency === stageIdx
+				);
+			}
+			return !actionGroup.dependentOnStage;
+		}
+		return false;
+	}
+
+	private copyArgsToCopies(
+		args: [string, string, ...string[]],
+		actionGroup: ActionGroup,
+	): LocalCopy[] {
+		let dest = args.pop();
+		// If this is not an absolute path, it's given relative to the current
+		// workdir
+		if (!path.isAbsolute(dest)) {
+			dest = path.join(actionGroup.workdir, dest);
+		}
+
+		return args.map(source => {
+			const normalized = path.normalize(source);
+			return {
+				source: normalized,
+				dest,
+			};
+		});
+	}
+}
+
+export default Stage;

--- a/package-lock.json
+++ b/package-lock.json
@@ -368,6 +368,11 @@
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
+    "arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg=="
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1115,13 +1120,12 @@
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
-      "dev": true
+      "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI="
     },
     "docker-file-parser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/docker-file-parser/-/docker-file-parser-1.0.3.tgz",
-      "integrity": "sha1-XRthzc8YgLpATL0vfnOetRmgupI="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/docker-file-parser/-/docker-file-parser-1.0.4.tgz",
+      "integrity": "sha512-djh3R7KXkEPm80PXK9xbz8bCfEFuU11Tmf5l9IXKdjBPx91/cOqhwOwtOq6s35B8TqrwY6L4xLphmyYmJT0ZXw=="
     },
     "docker-modem": {
       "version": "1.0.6",
@@ -2487,6 +2491,11 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
     },
     "map-cache": {
       "version": "0.2.2",
@@ -4687,7 +4696,6 @@
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
       "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -4696,8 +4704,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -4994,6 +5001,18 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "ts-node": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.0.3.tgz",
+      "integrity": "sha512-2qayBA4vdtVRuDo11DEFSsD/SFsBXQBRZZhbRGSIkmYmVkWjULn/GGMdG10KVqkaGndljfaTD8dKjWgcejO8YA==",
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^3.1.0",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^3.0.0"
+      }
     },
     "tslib": {
       "version": "1.9.3",
@@ -5310,6 +5329,11 @@
       "requires": {
         "camelcase": "^4.1.0"
       }
+    },
+    "yn": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.0.0.tgz",
+      "integrity": "sha512-+Wo/p5VRfxUgBUGy2j/6KX2mj9AYJWOHuhMjMcbBFc3y54o9/4buK1ksBvuiK01C3kby8DH9lSmJdSxw+4G/2Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
     "prettify": "prettier --config ./node_modules/resin-lint/config/.prettierrc --write \"{lib,test}/**/*.ts\"",
     "lint": "resin-lint --typescript lib/ test/ && tsc --noEmit",
     "build": "npm run clean && npm run prettify && tsc --project tsconfig.publish.json",
-    "build:test": "npm run clean && tsc --project . && cp -r test/contexts build/test/",
+    "build:test": "npm run clean && tsc --project . && npm run test:copy",
     "test": "npm run prettify && npm run lint && npm run test:cov",
-    "test:cov": "npm run build:test && nyc --produce-source-map mocha",
-    "test:fast": "npm run build:test && mocha"
+    "test:cov": "npm run build:test && nyc mocha",
+    "test:copy": "cp -r test/{contexts,dockerfiles} build/test/",
+    "test:fast": "TS_NODE_FILES=true npx mocha --opts . --require ts-node/register test/**/*.spec.ts",
+    "test:watch": "TS_NODE_FILES=true npx mocha --opts . --require ts-node/register test/**/*.spec.ts --watch --watch-extensions ts"
   },
   "author": "Cameron Diver <cameron@balena.io>",
   "license": "Apache-2.0",
@@ -52,7 +54,7 @@
   },
   "dependencies": {
     "bluebird": "^3.5.1",
-    "docker-file-parser": "^1.0.3",
+    "docker-file-parser": "^1.0.4",
     "dockerode": "^2.5.6",
     "husky": "^1.1.3",
     "lodash": "^4.17.10",
@@ -62,6 +64,7 @@
     "shell-escape": "^0.2.0",
     "shell-quote": "^1.6.1",
     "strict-event-emitter-types": "^2.0.0",
+    "ts-node": "^8.0.3",
     "typed-error": "^3.0.1"
   }
 }

--- a/test/dockerfiles/multi-stage/Dockerfile.a
+++ b/test/dockerfiles/multi-stage/Dockerfile.a
@@ -1,0 +1,8 @@
+FROM a
+RUN command
+FROM b
+COPY --from=0 test test2
+RUN command2
+FROM c
+COPY --from=1 test2 test3
+RUN command3

--- a/test/dockerfiles/multi-stage/Dockerfile.b
+++ b/test/dockerfiles/multi-stage/Dockerfile.b
@@ -1,0 +1,10 @@
+FROM a
+RUN command
+FROM b
+COPY --from=0 test test2
+RUN command2
+FROM c
+WORKDIR /usr/src/app
+COPY --from=1 test2 test3
+COPY --from=2 test3 test4
+RUN command3

--- a/test/dockerfiles/multi-stage/Dockerfile.c
+++ b/test/dockerfiles/multi-stage/Dockerfile.c
@@ -1,0 +1,7 @@
+FROM baseimage as base
+RUN cmd
+COPY a b
+RUN cmd2
+FROM baseimage2
+COPY --from=base b c
+CMD cmd3

--- a/test/dockerfiles/multi-stage/Dockerfile.d
+++ b/test/dockerfiles/multi-stage/Dockerfile.d
@@ -1,0 +1,7 @@
+FROM baseimage AS base
+RUN cmd
+COPY a b
+RUN cmd2
+FROM baseimage2
+COPY --from=0 b c
+CMD cmd3

--- a/test/dockerfiles/multi-stage/Dockerfile.e
+++ b/test/dockerfiles/multi-stage/Dockerfile.e
@@ -1,0 +1,7 @@
+FROM baseimage AS base
+RUN cmd
+COPY a b
+RUN ["cmd2"]
+FROM baseimage2
+COPY --from=missing b c
+CMD cmd3

--- a/test/dockerfiles/multi-stage/Dockerfile.f
+++ b/test/dockerfiles/multi-stage/Dockerfile.f
@@ -1,0 +1,7 @@
+FROM base
+RUN cmd
+FROM base2
+COPY --from=0 a b
+COPY --from=0 c d
+RUN command
+CMD cmd

--- a/test/dockerfiles/multi-stage/Dockerfile.g
+++ b/test/dockerfiles/multi-stage/Dockerfile.g
@@ -1,0 +1,18 @@
+FROM base AS base
+COPY trigger here
+RUN command
+
+FROM base2 AS base2
+COPY a b
+RUN command
+COPY --from=base c d
+RUN command2
+
+FROM base3 AS base3
+RUN command
+COPY --from=base2 e f
+RUN command2
+
+FROM base4 AS base4
+COPY --from=base3 f g
+CMD cmd

--- a/test/dockerfiles/multi-stage/Dockerfile.h
+++ b/test/dockerfiles/multi-stage/Dockerfile.h
@@ -1,0 +1,12 @@
+FROM base AS base
+COPY a b
+RUN command
+FROM base2 AS base2
+COPY a b
+RUN command1
+RUN command2
+COPY --from=base c d
+RUN command3
+RUN command4
+CMD cmd
+

--- a/test/dockerfiles/multi-stage/Dockerfile.i
+++ b/test/dockerfiles/multi-stage/Dockerfile.i
@@ -1,0 +1,10 @@
+FROM base as base
+COPY a b
+FROM base2 as base2
+COPY c d
+RUN command
+FROM base3 as base3
+COPY --from=base b c
+FROM base4 as base4
+COPY --from=base2 d e
+CMD cmd

--- a/test/dockerfiles/single-stage/Dockerfile.a
+++ b/test/dockerfiles/single-stage/Dockerfile.a
@@ -1,0 +1,4 @@
+FROM baseimage
+RUN somecommand
+RUN anothercommand
+RUN multi arg command

--- a/test/dockerfiles/single-stage/Dockerfile.b
+++ b/test/dockerfiles/single-stage/Dockerfile.b
@@ -1,0 +1,5 @@
+FROM baseimage
+RUN somecommand
+COPY a.ts b.ts
+RUN anothercommand
+RUN multi arg command

--- a/test/dockerfiles/single-stage/Dockerfile.c
+++ b/test/dockerfiles/single-stage/Dockerfile.c
@@ -1,0 +1,7 @@
+FROM baseimage
+RUN somecommand
+COPY a.ts b.ts
+RUN anothercommand
+RUN multi arg command
+COPY c.ts d.ts
+RUN second anothercommand

--- a/test/dockerfiles/single-stage/Dockerfile.d
+++ b/test/dockerfiles/single-stage/Dockerfile.d
@@ -1,0 +1,5 @@
+FROM baseimage
+RUN somecommand
+COPY --chown=root:root a.ts b.ts
+RUN anothercommand
+RUN multi arg command

--- a/test/dockerfiles/single-stage/Dockerfile.e
+++ b/test/dockerfiles/single-stage/Dockerfile.e
@@ -1,0 +1,9 @@
+
+FROM baseimage
+WORKDIR /usr/src/app
+COPY a.ts b.ts
+RUN anothercommand
+WORKDIR /usr/src/app/src/
+COPY c.ts d.ts
+RUN multi arg command
+RUN command2

--- a/test/dockerfiles/single-stage/Dockerfile.f
+++ b/test/dockerfiles/single-stage/Dockerfile.f
@@ -1,0 +1,5 @@
+FROM baseimage
+WORKDIR /usr/src/app
+COPY c.ts d.ts ./
+RUN command
+CMD command2

--- a/test/dockerfiles/single-stage/Dockerfile.g
+++ b/test/dockerfiles/single-stage/Dockerfile.g
@@ -1,0 +1,4 @@
+FROM image
+WORKDIR /usr/src/app
+COPY a.test b.test
+CMD test

--- a/test/dockerfiles/single-stage/Dockerfile.h
+++ b/test/dockerfiles/single-stage/Dockerfile.h
@@ -1,0 +1,7 @@
+FROM image
+WORKDIR /usr/src/app
+COPY a.test b.test
+COPY c.test d.test
+RUN command
+RUN command2
+CMD test

--- a/test/dockerfiles/single-stage/Dockerfile.i
+++ b/test/dockerfiles/single-stage/Dockerfile.i
@@ -1,0 +1,4 @@
+FROM test
+WORKDIR /usr/src/app
+COPY a.test .
+CMD cmd

--- a/test/dockerfiles/single-stage/Dockerfile.j
+++ b/test/dockerfiles/single-stage/Dockerfile.j
@@ -1,0 +1,7 @@
+FROM baseimage
+RUN command1
+COPY src/* src/
+RUN command2
+RUN command3
+COPY test/ test/
+RUN command4

--- a/test/dockerfiles/single-stage/Dockerfile.k
+++ b/test/dockerfiles/single-stage/Dockerfile.k
@@ -1,0 +1,5 @@
+FROM baseimage
+COPY src ./
+RUN command1
+COPY ./ src/
+RUN ["array", "based", "command"]

--- a/test/dockerfiles/single-stage/Dockerfile.l
+++ b/test/dockerfiles/single-stage/Dockerfile.l
@@ -1,0 +1,2 @@
+FROM baseimage
+ADD test test

--- a/test/dockerfiles/single-stage/Dockerfile.m
+++ b/test/dockerfiles/single-stage/Dockerfile.m
@@ -1,0 +1,1 @@
+FROM baseimage AS syntax error

--- a/test/dockerfiles/single-stage/Dockerfile.n
+++ b/test/dockerfiles/single-stage/Dockerfile.n
@@ -1,0 +1,4 @@
+FROM base
+COPY something here
+RUN test
+CMD cmd

--- a/test/dockerfiles/single-stage/Dockerfile.o
+++ b/test/dockerfiles/single-stage/Dockerfile.o
@@ -1,0 +1,5 @@
+FROM base
+COPY a b
+COPY c d
+RUN run
+CMD cmd

--- a/test/dockerfiles/single-stage/Dockerfile.p
+++ b/test/dockerfiles/single-stage/Dockerfile.p
@@ -1,0 +1,2 @@
+FROM base
+COPY a /usr/src/app/b

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,3 @@
 --timeout 600000
+--require source-map-support/register
 build/test/*.spec.js

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -1,0 +1,3 @@
+interface Dictionary<T> {
+	[key: string]: T;
+}


### PR DESCRIPTION
This leaves the `multistage-meta-branch` in an unbuildable (and unusable) state, but has been split up to aid reviewing.

We change the dockerfile parsing to have seperate instances per stage, and build dependency graphs on trigger to work out which stages have been invalidated.

Also add some helper scripts to package.json for TDD.