### PR TITLE
fix: Filter out links when copying between stages

### DIFF
--- a/lib/container.ts
+++ b/lib/container.ts
@@ -381,9 +381,19 @@ export class Container extends (EventEmitter as {
 		tarStream: Stream.Readable,
 		destination: string,
 	): Promise<void> {
-		await this.docker
-			.getContainer(this.containerId)
-			.putArchive(tarStream, { path: destination });
+		await new Promise((resolve, reject) => {
+			// We use the callback interface here, as the
+			// dockerode promise interface somehow loses any
+			// errors which occur
+			this.docker
+				.getContainer(this.containerId)
+				.putArchive(tarStream, { path: destination }, err => {
+					if (err) {
+						return reject(err);
+					}
+					resolve();
+				});
+		});
 	}
 }
 


### PR DESCRIPTION
This can cause build failures as the links can point to something which
doesn't exist in the later stage. We also switch to a callback interface
for the putArchive docker call, as errors were being masked.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>