### PR TITLE
Implement locking infrastructure for livepush process

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -6,3 +6,4 @@ export class ContainerNotRunningError extends TypedError {}
 export class InternalInconsistencyError extends TypedError {}
 export class RuntimeError extends TypedError {}
 export class InvalidArgumentError extends TypedError {}
+export class LivepushAlreadyRunningError extends TypedError {}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,13 +1,21 @@
 import Container from './container';
 import Dockerfile from './dockerfile';
-import { DockerfileParseError, RuntimeError, UnsupportedError } from './errors';
+import {
+	DockerfileParseError,
+	InvalidArgumentError,
+	LivepushAlreadyRunningError,
+	RuntimeError,
+	UnsupportedError,
+} from './errors';
 import Livepush from './livepush';
 
 export {
 	Container,
 	Dockerfile,
 	DockerfileParseError,
+	InvalidArgumentError,
 	Livepush,
+	LivepushAlreadyRunningError,
 	RuntimeError,
 	UnsupportedError,
 };


### PR DESCRIPTION
Before this change, multiple livepush processes could occur
simultaneously on the same containers. This commit adds a lock,
which will not allow a livepush process to start if another one is
running.

Change-type: patch
Closes: #35
Signed-off-by: Cameron Diver <cameron@balena.io>