### PR TITLE
Preprocess the dockerfile by removing all comments

### DIFF
--- a/lib/dockerfile.ts
+++ b/lib/dockerfile.ts
@@ -85,6 +85,14 @@ export class Dockerfile {
 	}
 
 	private parse(dockerfileContent: string) {
+		// Until https://github.com/joyent/node-docker-file-parser/issues/8
+		// is fixed, we first remove all comments from the
+		// dockerfile
+		dockerfileContent = dockerfileContent
+			.split(/\r?\n/)
+			.filter(line => !line.trimLeft().startsWith('#'))
+			.join('\n');
+
 		const entries = parser.parse(dockerfileContent, {
 			includeComments: false,
 		});

--- a/test/dockerfile.spec.ts
+++ b/test/dockerfile.spec.ts
@@ -132,6 +132,16 @@ describe('Dockerfile', () => {
 				]);
 			});
 
+			it('should handle comments within commands', () => {
+				const dockerfile = new Dockerfile(dockerfileContent['single-r']);
+				expect(dockerfile.stages).to.have.length(1);
+				expect(dockerfile.stages[0].actionGroups).to.have.length(1);
+				const ag = dockerfile.stages[0].actionGroups[0];
+
+				expect(ag.commands).to.have.length(1);
+				expect(ag.commands[0]).to.equal(`echo 'hello' && echo ' world'`);
+			});
+
 			it('should handle workdir commands', () => {
 				const dockerfile = new Dockerfile(dockerfileContent['single-e']);
 				expect(dockerfile.stages).to.have.length(1);

--- a/test/dockerfiles/single-stage/Dockerfile.r
+++ b/test/dockerfiles/single-stage/Dockerfile.r
@@ -1,0 +1,5 @@
+FROM image
+
+RUN echo 'hello' && \
+# A comment within the command
+echo ' world'


### PR DESCRIPTION
This fixes a bug in the dockerfile parsing library that we use:
https://github.com/joyent/node-docker-file-parser/issues/8

Ideally we'd like to remove this code, so once the above issue is fixed,
it will be removed and updated.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>