### PR TITLE
Force POSIX format for destination (device) path operations on Windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 build
 coverage
 .nyc*
+.idea

--- a/lib/container.ts
+++ b/lib/container.ts
@@ -311,7 +311,6 @@ export class Container extends (EventEmitter as {
 					// check the string itself. Any path ending with / is quite clearly
 					// a directory, and it means that we can avoid making another docker
 					// call
-					// TODO: Think about how this is affected when using windows
 					const destinationIsDirectory =
 						_.endsWith(copy.dest, '/') ||
 						(await this.pathIsDirectory(copy.dest));
@@ -327,17 +326,19 @@ export class Container extends (EventEmitter as {
 					// as the source. We also check that we are not
 					// using a glob, by checking the existence of the source
 					const realSource = Path.join(this.buildContext, copy.source);
-					let filepath = file;
+					// Convert to posix style path for windows only (to preserve any escape chars in non-windows paths)
+					let filepath =
+						process.platform === 'win32' ? file.replace(/\\/g, '/') : file;
 					if (
 						!sourceIsDirectory &&
 						copy.source !== filepath &&
 						(await fs.exists(realSource))
 					) {
-						filepath = Path.relative(copy.source, filepath);
+						filepath = Path.posix.relative(copy.source, filepath);
 					}
 
 					const toPath = destinationIsDirectory
-						? Path.join(copy.dest, filepath)
+						? Path.posix.join(copy.dest, filepath)
 						: copy.dest;
 
 					return {

--- a/lib/stage-copy.ts
+++ b/lib/stage-copy.ts
@@ -147,6 +147,7 @@ export function resolveFileDestination(
 	dest: string,
 	pathInTar: string,
 ) {
+	// TODO: source.split probably needs to use native separator (i.e. path.sep), but needs investigating.
 	const sourceParts = source.split('/').filter(p => p !== '');
 	let pathParts = pathInTar.split('/').filter(p => p !== '');
 

--- a/lib/stage.ts
+++ b/lib/stage.ts
@@ -232,11 +232,11 @@ export class Stage {
 		// If this is not an absolute path, it's given relative to the current
 		// workdir
 		if (!path.isAbsolute(dest)) {
-			dest = path.join(actionGroup.workdir, dest);
+			dest = path.posix.join(actionGroup.workdir, dest);
 		}
 
 		return args.map(source => {
-			const normalized = path.normalize(source);
+			const normalized = path.posix.normalize(source);
 			return {
 				source: normalized,
 				dest,


### PR DESCRIPTION
Fixes issues with livepush changes not getting applied properly from Windows.

Resolves: #55
Change-type: patch
Signed-off-by: Scott Lowe <scott@balena.io>