### PR TITLE
Add support for Dockerfile directives

### DIFF
--- a/lib/dockerfile-parser.ts
+++ b/lib/dockerfile-parser.ts
@@ -1,0 +1,114 @@
+import { CommandEntry, parse } from 'docker-file-parser';
+
+const LiveCommandDirective = 'dev-cmd-live';
+const EscapeDirective = 'escape';
+
+export function parseDockerfile(content: string | Buffer): CommandEntry[] {
+	// This function may look a little weird, but due to bugs
+	// in the comment parsing of docker-file-parser we first go
+	// through the dockerfile, find out directives, and keep a
+	// track of the line number that it was encountered at.
+	// We then pass to the docker-file-parser parsing
+	// function, with no comments. We then integrate the
+	// directive into the returned values using the line
+	// number (as the order matters).
+
+	// issue with comments in docker-file-parser:
+	// https://github.com/joyent/node-docker-file-parser/issues/8
+
+	if (Buffer.isBuffer(content)) {
+		content = content.toString();
+	}
+
+	// We keep track of this, as one of the directives can
+	// change it
+	let escapeCharacter = '\\';
+	let lastNonCommentLine = '';
+
+	const directives: CommandEntry[] = [];
+	const nonCommentLines = content
+		.split(/\r?\n/)
+		.map((line, idx) => {
+			// If the line is a comment, we're only interested in it
+			// if it's a livepush directive
+			const comment = extractComment(line);
+
+			if (comment) {
+				const directive = extractDirective(comment, idx + 1);
+				if (directive) {
+					directives.push(directive.entry);
+
+					// Special case, keep track of the escape directive
+					if (directive.entry.name === 'ESCAPE') {
+						escapeCharacter = (directive.entry.args as string[])[0];
+					}
+
+					return directive.preserve ? line : '';
+				}
+				// We still add an empty line when we encounter a
+				// comment, to keep the line numbers consistent
+				// If the last non-commented line ends with an
+				// escape character, keep that going
+				if (lastNonCommentLine.endsWith(escapeCharacter)) {
+					return `${escapeCharacter}`;
+				}
+				return '';
+			}
+			lastNonCommentLine = line;
+			return line;
+		})
+		.join('\n');
+
+	const commands = parse(nonCommentLines, { includeComments: false });
+
+	// Concatenate the commands and directives, and sort by
+	// the line numbers
+	return commands.concat(directives).sort((a, b) => a.lineno - b.lineno);
+}
+
+function extractComment(line: string) {
+	if (/^\s*#+/.test(line)) {
+		return line.replace(/^\s*#+\s*(.*)/, '$1');
+	}
+	return;
+}
+
+// TODO: Perhaps make this regex more strict?
+const directiveRegex = /(.+)=(.+)/;
+function extractDirective(
+	comment: string,
+	lineno: number,
+): { entry: CommandEntry; preserve: boolean } | undefined {
+	const match = comment.match(directiveRegex);
+	if (!match) {
+		return;
+	}
+
+	const common = {
+		args: match[2],
+		lineno,
+		raw: comment,
+	};
+
+	switch (match[1].toLowerCase()) {
+		case LiveCommandDirective:
+			return {
+				entry: {
+					name: 'LIVECMD',
+					...common,
+				},
+				preserve: false,
+			};
+		case EscapeDirective:
+			return {
+				entry: {
+					name: 'ESCAPE',
+					...common,
+				},
+				// We have to preserve this in the original
+				// dockerfile so that docker-file-parser can handle
+				// it correctly
+				preserve: true,
+			};
+	}
+}

--- a/lib/dockerfile.ts
+++ b/lib/dockerfile.ts
@@ -10,11 +10,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import * as parser from 'docker-file-parser';
 import * as _ from 'lodash';
 import * as path from 'path';
 
 import ActionGroup from './action-group';
+import { parseDockerfile } from './dockerfile-parser';
 import { DockerfileParseError, UnsupportedError } from './errors';
 import Stage from './stage';
 
@@ -85,17 +85,7 @@ export class Dockerfile {
 	}
 
 	private parse(dockerfileContent: string) {
-		// Until https://github.com/joyent/node-docker-file-parser/issues/8
-		// is fixed, we first remove all comments from the
-		// dockerfile
-		dockerfileContent = dockerfileContent
-			.split(/\r?\n/)
-			.filter(line => !line.trimLeft().startsWith('#'))
-			.join('\n');
-
-		const entries = parser.parse(dockerfileContent, {
-			includeComments: false,
-		});
+		const entries = parseDockerfile(dockerfileContent);
 
 		let currentStage: Stage | null = null;
 		let stageIdx = 0;

--- a/test/dockerfile-parser.spec.ts
+++ b/test/dockerfile-parser.spec.ts
@@ -1,0 +1,115 @@
+import { expect } from 'chai';
+
+import { parseDockerfile } from '../lib/dockerfile-parser';
+
+describe('Dockerfile parsing', () => {
+	describe('Dockerfile directives', () => {
+		it('should correctly parse Dockerfile directives', () => {
+			expect(
+				parseDockerfile('#dev-cmd-live=webpack-dev-server\n'),
+			).to.deep.equal([
+				{
+					name: 'LIVECMD',
+					args: 'webpack-dev-server',
+					lineno: 1,
+					raw: 'dev-cmd-live=webpack-dev-server',
+				},
+			]);
+		});
+
+		it('should correctly parse Dockerfile directives with spaces', () => {
+			expect(
+				parseDockerfile('\n\n\n#      dev-cmd-live=webpack-dev-server\n'),
+			).to.deep.equal([
+				{
+					name: 'LIVECMD',
+					args: 'webpack-dev-server',
+					lineno: 4,
+					raw: 'dev-cmd-live=webpack-dev-server',
+				},
+			]);
+		});
+
+		it('should sort Dockerfile directives correctly with normal commands', () => {
+			expect(
+				parseDockerfile(
+					[
+						'FROM base',
+						'RUN 1',
+						'COPY 1',
+						'#dev-cmd-live=webpack-dev-server',
+						'COPY 2',
+						'RUN 2',
+						'CMD cmd',
+					].join('\n'),
+				).map(({ name }) => name),
+			).to.deep.equal(['FROM', 'RUN', 'COPY', 'LIVECMD', 'COPY', 'RUN', 'CMD']);
+
+			expect(
+				parseDockerfile(
+					[
+						'FROM base',
+						'RUN 1',
+						'COPY 1',
+						'COPY 2',
+						'RUN 2',
+						'CMD cmd',
+						'#dev-cmd-live=webpack-dev-server',
+					].join('\n'),
+				).map(({ name }) => name),
+			).to.deep.equal(['FROM', 'RUN', 'COPY', 'COPY', 'RUN', 'CMD', 'LIVECMD']);
+		});
+
+		it('should sort directives correctly even with empty lines and comments', () => {
+			expect(
+				parseDockerfile(
+					[
+						'FROM base',
+						'',
+						'RUN 1',
+						'# a comment',
+						'COPY 1',
+						'',
+						'# another comment',
+						'COPY 2',
+						'RUN 2',
+						'',
+						'',
+						'',
+						'CMD cmd',
+						'#dev-cmd-live=webpack-dev-server',
+					].join('\n'),
+				).map(({ name }) => name),
+			).to.deep.equal(['FROM', 'RUN', 'COPY', 'COPY', 'RUN', 'CMD', 'LIVECMD']);
+		});
+	});
+
+	it('should correctly parse leading spaces', () => {
+		expect(
+			parseDockerfile(
+				['FROM a', `RUN echo 'test\\`, `      test'`, 'CMD test'].join('\n'),
+			),
+		).to.deep.equal([
+			{
+				name: 'FROM',
+				lineno: 1,
+				raw: 'FROM a',
+				args: 'a',
+			},
+			{
+				name: 'RUN',
+				raw: `RUN echo 'test      test'`,
+				// This represent the line which the command
+				// *finishes* on
+				lineno: 3,
+				args: `echo 'test      test'`,
+			},
+			{
+				name: 'CMD',
+				lineno: 4,
+				args: 'test',
+				raw: 'CMD test',
+			},
+		]);
+	});
+});


### PR DESCRIPTION
Because of issues in docker-file-parser:
  https://github.com/joyent/node-docker-file-parser/issues/8
we have to first keep track of dockerfile directives, and fold
them into the parsing performed by the external module.

We also have to keep track of the escape directive, so that we can
ensure we parse comments in the middle of commands correctly.

This work leads the way to being able to specify livepush behaviour
using dockerfile directives.

Chnage-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>