### PR TITLE
Add support for livecmds

### DIFF
--- a/lib/dockerfile-parser.ts
+++ b/lib/dockerfile-parser.ts
@@ -3,6 +3,8 @@ import { CommandEntry, parse } from 'docker-file-parser';
 const LiveCommandDirective = 'dev-cmd-live';
 const EscapeDirective = 'escape';
 
+export { CommandEntry };
+
 export function parseDockerfile(content: string | Buffer): CommandEntry[] {
 	// This function may look a little weird, but due to bugs
 	// in the comment parsing of docker-file-parser we first go
@@ -87,7 +89,7 @@ function extractDirective(
 	const common = {
 		args: match[2],
 		lineno,
-		raw: comment,
+		raw: `#${comment}`,
 	};
 
 	switch (match[1].toLowerCase()) {

--- a/lib/livepush.ts
+++ b/lib/livepush.ts
@@ -88,12 +88,15 @@ export class Livepush extends (EventEmitter as {
 				{ skipRestart: true },
 			);
 		}
+
+		const skipRestart = opts.skipContainerRestart || dockerfile.hasLiveCmd();
+
 		containers[dockerfile.stages.length - 1] = Container.fromContainerId(
 			opts.context,
 			opts.docker,
 			opts.containerId,
 			{
-				skipRestart: opts.skipContainerRestart ?? false,
+				skipRestart,
 			},
 		);
 

--- a/test/dockerfile-parser.spec.ts
+++ b/test/dockerfile-parser.spec.ts
@@ -12,7 +12,7 @@ describe('Dockerfile parsing', () => {
 					name: 'LIVECMD',
 					args: 'webpack-dev-server',
 					lineno: 1,
-					raw: 'dev-cmd-live=webpack-dev-server',
+					raw: '#dev-cmd-live=webpack-dev-server',
 				},
 			]);
 		});
@@ -25,7 +25,7 @@ describe('Dockerfile parsing', () => {
 					name: 'LIVECMD',
 					args: 'webpack-dev-server',
 					lineno: 4,
-					raw: 'dev-cmd-live=webpack-dev-server',
+					raw: '#dev-cmd-live=webpack-dev-server',
 				},
 			]);
 		});

--- a/test/dockerfiles/livecmd/Dockerfile.a
+++ b/test/dockerfiles/livecmd/Dockerfile.a
@@ -1,0 +1,13 @@
+FROM base
+
+RUN command
+
+COPY file file
+
+RUN command2
+
+COPY file2 file2
+
+#dev-cmd-live=livecmd
+
+CMD othercmd

--- a/test/dockerfiles/livecmd/Dockerfile.b
+++ b/test/dockerfiles/livecmd/Dockerfile.b
@@ -1,0 +1,7 @@
+FROM a
+
+#dev-cmd-live=cmd
+
+FROM b
+
+CMD c

--- a/test/dockerfiles/livecmd/Dockerfile.c
+++ b/test/dockerfiles/livecmd/Dockerfile.c
@@ -1,0 +1,9 @@
+
+FROM a
+
+
+FROM b
+#dev-cmd-live=cmd
+#dev-cmd-live=cmd
+
+CMD c

--- a/test/dockerfiles/livecmd/Dockerfile.d
+++ b/test/dockerfiles/livecmd/Dockerfile.d
@@ -1,0 +1,9 @@
+FROM test
+
+RUN ["my", "command"]
+
+#dev-cmd-live=test
+
+COPY ["asd", "asd"]
+
+CMD test

--- a/test/dockerfiles/livecmd/Dockerfile.e
+++ b/test/dockerfiles/livecmd/Dockerfile.e
@@ -1,0 +1,4 @@
+FROM test
+#dev-cmd-live=test
+#escape=\
+CMD test

--- a/test/dockerfiles/livecmd/Dockerfile.f
+++ b/test/dockerfiles/livecmd/Dockerfile.f
@@ -1,0 +1,8 @@
+FROM a
+
+COPY b b
+RUN b
+
+#dev-cmd-live=asd
+FROM ddd
+CMD ddd


### PR DESCRIPTION
This is a new method of allowing Dockerfiles to specificy a command
that will be run when the container is started with livepush. We
generate a new Dockerfile with this command in mind, and replace
the internal representation with this but also return it so the
build process can use that.

Change-type: minor
Signed-off-by: Cameron Diver <cameron@balena.io>