### PR TITLE
Fix parsing of livecmds with = in them

### DIFF
--- a/lib/dockerfile-parser.ts
+++ b/lib/dockerfile-parser.ts
@@ -76,7 +76,7 @@ function extractComment(line: string) {
 }
 
 // TODO: Perhaps make this regex more strict?
-const directiveRegex = /(.+)=(.+)/;
+const directiveRegex = /([^=]+)=(.+)/;
 function extractDirective(
 	comment: string,
 	lineno: number,

--- a/test/dockerfile.spec.ts
+++ b/test/dockerfile.spec.ts
@@ -560,6 +560,13 @@ describe('Dockerfile', () => {
 				.that.equals('livecmd');
 		});
 
+		it('should correctly store a livecmd with an equals in it', () => {
+			const dockerfile = new Dockerfile(dockerfileContent['livecmd-g']);
+			expect(dockerfile)
+				.to.have.property('liveCmd')
+				.that.equals('LIVEPUSH=1 my-command arguments');
+		});
+
 		it('should throw an error if a livecmd appears in an intermediate stage', () => {
 			expect(
 				() => new Dockerfile(dockerfileContent['livecmd-b']),

--- a/test/dockerfiles/livecmd/Dockerfile.g
+++ b/test/dockerfiles/livecmd/Dockerfile.g
@@ -1,0 +1,3 @@
+FROM asd
+
+#dev-cmd-live=LIVEPUSH=1 my-command arguments


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>