### PR TITLE
Fix restart detection in livecmd based Dockerfiles

### DIFF
--- a/lib/action-group.ts
+++ b/lib/action-group.ts
@@ -30,6 +30,7 @@ export interface LocalCopy {
 interface ActionGroupCore {
 	commands: Command[];
 	workdir: string;
+	restart: boolean;
 }
 
 export interface StageDependentActionGroup extends ActionGroupCore {

--- a/lib/container.ts
+++ b/lib/container.ts
@@ -191,7 +191,7 @@ export class Container extends (EventEmitter as {
 		}
 
 		// If we made any changes, restart the container
-		if (!this.skipRestart && actionGroups.length > 0) {
+		if (!this.skipRestart && this.requiresRestart(actionGroups)) {
 			this.emit('containerRestart');
 			await this.restartContainer();
 		}
@@ -241,6 +241,10 @@ export class Container extends (EventEmitter as {
 
 	public setBuildArguments(buildArgs: Dictionary<string>): void {
 		this.buildArguments = buildArgs;
+	}
+
+	private requiresRestart(actionGroups: ActionGroup[]): boolean {
+		return _.some(actionGroups, 'restart');
 	}
 
 	private async runActionGroupCommand(command: string): Promise<number> {

--- a/lib/dockerfile-parser.ts
+++ b/lib/dockerfile-parser.ts
@@ -2,6 +2,7 @@ import { CommandEntry, parse } from 'docker-file-parser';
 
 const LiveCommandDirective = 'dev-cmd-live';
 const EscapeDirective = 'escape';
+const InternalLiveCmdMarker = 'livecmd-marker';
 
 export { CommandEntry };
 
@@ -111,6 +112,14 @@ function extractDirective(
 				// dockerfile so that docker-file-parser can handle
 				// it correctly
 				preserve: true,
+			};
+		case InternalLiveCmdMarker:
+			return {
+				entry: {
+					name: 'LIVECMD_MARKER',
+					...common,
+				},
+				preserve: false,
 			};
 	}
 }

--- a/lib/livepush.ts
+++ b/lib/livepush.ts
@@ -89,14 +89,12 @@ export class Livepush extends (EventEmitter as {
 			);
 		}
 
-		const skipRestart = opts.skipContainerRestart || dockerfile.hasLiveCmd();
-
 		containers[dockerfile.stages.length - 1] = Container.fromContainerId(
 			opts.context,
 			opts.docker,
 			opts.containerId,
 			{
-				skipRestart,
+				skipRestart: opts.skipContainerRestart || false,
 			},
 		);
 

--- a/lib/stage.ts
+++ b/lib/stage.ts
@@ -31,6 +31,7 @@ export class Stage {
 			commands: [],
 			copies: [],
 			workdir: '/',
+			restart: true,
 		},
 	];
 
@@ -49,7 +50,7 @@ export class Stage {
 		public name: string = index.toString(),
 	) {}
 
-	public addLocalCopyStep(args: string[]) {
+	public addLocalCopyStep(args: string[], restartRequired: boolean) {
 		const lastActionGroup = _.last(this.actionGroups)!;
 
 		if (args.length < 2) {
@@ -78,6 +79,7 @@ export class Stage {
 				commands: [],
 				copies: [],
 				workdir: this.lastWorkdir,
+				restart: restartRequired,
 			};
 			actionGroup.copies = this.copyArgsToCopies(checkedArgs, actionGroup);
 			this.actionGroups.push(actionGroup);
@@ -87,7 +89,11 @@ export class Stage {
 		this.lastStepWasCopy = true;
 	}
 
-	public addStageCopyStep(args: string[], stageIdx: number) {
+	public addStageCopyStep(
+		args: string[],
+		stageIdx: number,
+		restartRequired: boolean,
+	) {
 		const lastActionGroup = _.last(this.actionGroups)!;
 
 		if (args.length < 2) {
@@ -121,6 +127,7 @@ export class Stage {
 				stageDependency: stageIdx,
 				copies: [],
 				workdir: this.lastWorkdir,
+				restart: restartRequired,
 			};
 
 			actionGroup.copies = this.copyArgsToCopies(checkedArgs, actionGroup).map(
@@ -144,7 +151,7 @@ export class Stage {
 		this.lastStepWasCopy = false;
 	}
 
-	public addWorkdirStep(workdir: string) {
+	public addWorkdirStep(workdir: string, restartRequired: boolean) {
 		// We need to create a new group, saving any ungrouped commands into
 		// the latest group
 		const actionGroup = _.last(this.actionGroups)!;
@@ -154,6 +161,7 @@ export class Stage {
 			dependentOnStage: false,
 			commands: [],
 			workdir,
+			restart: restartRequired,
 		});
 		this.lastWorkdir = workdir;
 		this.ungroupedCommands = [];
@@ -201,6 +209,10 @@ export class Stage {
 		}
 
 		return [];
+	}
+
+	public liveCmdFound() {
+		this.lastStepWasCopy = false;
 	}
 
 	private canAddCopyToGroup(dependentOnStage: false): boolean;

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "build": "npm run clean && tsc --project tsconfig.publish.json",
     "build:test": "npm run clean && tsc --project . && npm run test:copy",
     "test": "npm run lint && npm run test:cov",
-    "test:cov": "npm run build:test && nyc mocha build/test/*.spec.js",
+    "test:cov": "npm run build:test && nyc mocha --opts test/mocha.prod.opts build/test/*.spec.js",
     "test:copy": "cp -r test/contexts build/test/; cp -r test/dockerfiles build/test/",
-    "test:fast": "TS_NODE_FILES=true npx mocha --require ts-node/register test/**/*.spec.ts",
-    "test:watch": "TS_NODE_FILES=true npx mocha --require ts-node/register test/**/*.spec.ts --watch --watch-extensions ts"
+    "test:fast": "TS_NODE_FILES=true npx mocha",
+    "test:watch": "TS_NODE_FILES=true npx mocha --watch --watch-extensions ts"
   },
   "author": "Cameron Diver <cameron@balena.io>",
   "license": "Apache-2.0",

--- a/test/mocha.prod.opts
+++ b/test/mocha.prod.opts
@@ -1,5 +1,4 @@
 --timeout 600000
 --exit
 --require source-map-support/register
---require ts-node/register/transpile-only
-test/**/*.spec.ts
+build/test/*.js


### PR DESCRIPTION
When generating the new dockerfile, we leave ourselves a marker so that we know anything appearing before that should cause a restart, and anything appearing afterwards should not.