### PR TITLE
Add support for live runs and live copies

### DIFF
--- a/lib/dockerfile-parser.ts
+++ b/lib/dockerfile-parser.ts
@@ -2,6 +2,7 @@ import { CommandEntry, parse } from 'docker-file-parser';
 
 const LiveCommandDirective = 'dev-cmd-live';
 const RunCommandDirective = 'dev-run';
+const CopyCommandDirective = 'dev-copy';
 const EscapeDirective = 'escape';
 const InternalLiveCmdMarker = 'livecmd-marker';
 
@@ -126,6 +127,14 @@ function extractDirective(
 			return {
 				entry: {
 					name: 'LIVERUN',
+					...common,
+				},
+				preserve: false,
+			};
+		case CopyCommandDirective:
+			return {
+				entry: {
+					name: 'LIVECOPY',
 					...common,
 				},
 				preserve: false,

--- a/lib/dockerfile-parser.ts
+++ b/lib/dockerfile-parser.ts
@@ -1,6 +1,7 @@
 import { CommandEntry, parse } from 'docker-file-parser';
 
 const LiveCommandDirective = 'dev-cmd-live';
+const RunCommandDirective = 'dev-run';
 const EscapeDirective = 'escape';
 const InternalLiveCmdMarker = 'livecmd-marker';
 
@@ -117,6 +118,14 @@ function extractDirective(
 			return {
 				entry: {
 					name: 'LIVECMD_MARKER',
+					...common,
+				},
+				preserve: false,
+			};
+		case RunCommandDirective:
+			return {
+				entry: {
+					name: 'LIVERUN',
 					...common,
 				},
 				preserve: false,

--- a/lib/dockerfile.ts
+++ b/lib/dockerfile.ts
@@ -97,7 +97,7 @@ export class Dockerfile {
 	}
 
 	public generateLiveDockerfile(): string {
-		// First, if there's no live cmd, we can just return the
+		// First, if there's no live action, we can just return the
 		// original dockerfile
 		if (!this.hasLiveAction) {
 			return this.dockerfileContent;
@@ -143,7 +143,13 @@ export class Dockerfile {
 				// permissive)
 				liveDockerfile += `CMD ${entry.args}\n`;
 			} else if (entry.name === 'LIVERUN') {
-				liveDockerfile += `RUN ${entry.args}`;
+				// LIVERUN commmands just go straight to the
+				// resulting dockerfile
+				liveDockerfile += `RUN ${entry.args}\n`;
+			} else if (entry.name === 'LIVECOPY') {
+				// LIVECOPY commands just go straight to the
+				// resulting dockerfile
+				liveDockerfile += `COPY ${entry.args}\n`;
 			} else if (entry.name === 'CMD') {
 				if (!this.liveCmd) {
 					liveDockerfile += `${entry.raw}\n`;
@@ -262,6 +268,9 @@ export class Dockerfile {
 					this.liveCmd = entry.args as string;
 					break;
 				case 'LIVERUN':
+					this.hasLiveAction = true;
+					break;
+				case 'LIVECOPY':
 					this.hasLiveAction = true;
 					break;
 				case 'LIVECMD_MARKER':

--- a/lib/stage.ts
+++ b/lib/stage.ts
@@ -168,9 +168,23 @@ export class Stage {
 		this.lastStepWasCopy = false;
 	}
 
-	public finalize() {
+	public finalize(restart: boolean) {
 		const actionGroup = _.last(this.actionGroups) as ActionGroup;
-		actionGroup.commands = actionGroup.commands.concat(this.ungroupedCommands);
+		if (actionGroup.restart !== restart) {
+			// Don't try to group together the commands, as we
+			// could get unwanted restarts
+			this.actionGroups.push({
+				dependentOnStage: false,
+				commands: this.ungroupedCommands,
+				copies: [],
+				restart,
+				workdir: this.lastWorkdir,
+			});
+		} else {
+			actionGroup.commands = actionGroup.commands.concat(
+				this.ungroupedCommands,
+			);
+		}
 
 		// Also filter any action groups which do not have commands or copies,
 		// as these are pointless

--- a/test/dockerfile-parser.spec.ts
+++ b/test/dockerfile-parser.spec.ts
@@ -142,4 +142,26 @@ describe('Dockerfile parsing', () => {
 			},
 		]);
 	});
+
+	it('should correctly parse live COPY commands', () => {
+		expect(parseDockerfile('#dev-copy=asd')).to.deep.equal([
+			{
+				name: 'LIVECOPY',
+				lineno: 1,
+				raw: '#dev-copy=asd',
+				args: 'asd',
+			},
+		]);
+	});
+
+	it('should correctly parse live COPY commands with spaces', () => {
+		expect(parseDockerfile('#dev-copy=file1 file2')).to.deep.equal([
+			{
+				name: 'LIVECOPY',
+				lineno: 1,
+				raw: '#dev-copy=file1 file2',
+				args: 'file1 file2',
+			},
+		]);
+	});
 });

--- a/test/dockerfile-parser.spec.ts
+++ b/test/dockerfile-parser.spec.ts
@@ -112,4 +112,34 @@ describe('Dockerfile parsing', () => {
 			},
 		]);
 	});
+
+	it('should correctly parse live RUN commands', () => {
+		expect(parseDockerfile('#dev-run=run-this-command')).to.deep.equal([
+			{
+				name: 'LIVERUN',
+				lineno: 1,
+				raw: '#dev-run=run-this-command',
+				args: 'run-this-command',
+			},
+		]);
+		expect(parseDockerfile('#dev-run=run --this --command')).to.deep.equal([
+			{
+				name: 'LIVERUN',
+				lineno: 1,
+				raw: '#dev-run=run --this --command',
+				args: 'run --this --command',
+			},
+		]);
+	});
+
+	it('should correctly parse live RUN commands with exec arguments', () => {
+		expect(parseDockerfile('#dev-run=["some", "executable"]')).to.deep.equal([
+			{
+				name: 'LIVERUN',
+				lineno: 1,
+				raw: '#dev-run=["some", "executable"]',
+				args: '["some", "executable"]',
+			},
+		]);
+	});
 });

--- a/test/dockerfile.spec.ts
+++ b/test/dockerfile.spec.ts
@@ -642,11 +642,11 @@ describe('Dockerfile', () => {
 
 			it('should correctly generate live run commands', () => {
 				const dockerfile = new Dockerfile(
-					['FROM asd', '#dev-run=run --this --command'].join('\n'),
+					['FROM asd', '#dev-run=run --this --command\n'].join('\n'),
 				);
 
 				expect(dockerfile.generateLiveDockerfile()).to.deep.equal(
-					['FROM asd', 'RUN run --this --command'].join('\n'),
+					['FROM asd', 'RUN run --this --command\n'].join('\n'),
 				);
 			});
 
@@ -664,7 +664,29 @@ describe('Dockerfile', () => {
 						'FROM asd',
 						'#livecmd-marker=1',
 						'CMD livecmd',
-						'RUN another-command',
+						'RUN another-command\n',
+					].join('\n'),
+				);
+			});
+
+			it('should correctly generate live copies', () => {
+				const dockerfile = new Dockerfile(
+					[
+						'FROM asd',
+						'#dev-copy=file1 file2',
+						'COPY asd asd',
+						'RUN command',
+						'CMD asd',
+					].join('\n'),
+				);
+
+				expect(dockerfile.generateLiveDockerfile()).to.deep.equal(
+					[
+						'FROM asd',
+						'COPY file1 file2',
+						'COPY asd asd',
+						'RUN command',
+						'CMD asd\n',
 					].join('\n'),
 				);
 			});
@@ -727,9 +749,10 @@ describe('Dockerfile', () => {
 
 				expect(dockerfile.stages).to.have.length(1);
 				const stage = dockerfile.stages[0];
-				expect(stage.actionGroups).to.have.length(2);
+				expect(stage.actionGroups).to.have.length(3);
 				expect(stage.actionGroups[0].restart).to.be.true;
-				expect(stage.actionGroups[1].restart).to.be.false;
+				expect(stage.actionGroups[1].restart).to.be.true;
+				expect(stage.actionGroups[2].restart).to.be.false;
 			});
 		});
 	});

--- a/test/dockerfile.spec.ts
+++ b/test/dockerfile.spec.ts
@@ -634,10 +634,39 @@ describe('Dockerfile', () => {
 				);
 			});
 
-			it('should replace the internal represntation after generating the dockerfile', () => {
+			it('should replace the internal representation after generating the dockerfile', () => {
 				const dockerfile = new Dockerfile(dockerfileContent['livecmd-f']);
 				dockerfile.generateLiveDockerfile();
 				expect(dockerfile.stages).to.have.length(1);
+			});
+
+			it('should correctly generate live run commands', () => {
+				const dockerfile = new Dockerfile(
+					['FROM asd', '#dev-run=run --this --command'].join('\n'),
+				);
+
+				expect(dockerfile.generateLiveDockerfile()).to.deep.equal(
+					['FROM asd', 'RUN run --this --command'].join('\n'),
+				);
+			});
+
+			it('should include live run commands after livecmds', () => {
+				const dockerfile = new Dockerfile(
+					[
+						'FROM asd',
+						'#dev-cmd-live=livecmd',
+						'#dev-run=another-command',
+					].join('\n'),
+				);
+
+				expect(dockerfile.generateLiveDockerfile()).to.deep.equal(
+					[
+						'FROM asd',
+						'#livecmd-marker=1',
+						'CMD livecmd',
+						'RUN another-command',
+					].join('\n'),
+				);
 			});
 		});
 
@@ -663,6 +692,44 @@ describe('Dockerfile', () => {
 				expect(stage.actionGroups[0].restart).to.be.true;
 				expect(stage.actionGroups[1].restart).to.be.true;
 				expect(stage.actionGroups[2].restart).to.be.false;
+			});
+
+			it('should not restart a container when a live run appears after a livecmd', () => {
+				const dockerfile = new Dockerfile(
+					[
+						'FROM asd',
+						'#dev-cmd-live=livecmd',
+						'#dev-run=another-command',
+					].join('\n'),
+				);
+
+				expect(dockerfile.stages).to.have.length(1);
+				const stage = dockerfile.stages[0];
+				expect(stage.actionGroups).to.have.length(1);
+				expect(stage.actionGroups[0].restart).to.be.false;
+			});
+
+			it('should work out which restarts to cause in a larger dockerfile', () => {
+				const dockerfile = new Dockerfile(
+					[
+						'FROM asd',
+						'COPY a b',
+						'RUN a b',
+						'#dev-run=first-command',
+						'COPY b c',
+						'RUN b c',
+						'#dev-cmd-live=livecmd',
+						'#dev-run=another-command',
+						'COPY a c',
+						'RUN b c',
+					].join('\n'),
+				);
+
+				expect(dockerfile.stages).to.have.length(1);
+				const stage = dockerfile.stages[0];
+				expect(stage.actionGroups).to.have.length(2);
+				expect(stage.actionGroups[0].restart).to.be.true;
+				expect(stage.actionGroups[1].restart).to.be.false;
 			});
 		});
 	});


### PR DESCRIPTION
These are added as dockerfile directives, and then generated by livepush into the dockerfile.

Closes: #73 